### PR TITLE
(feat) Raise if server unexpectedly closes

### DIFF
--- a/lowhaio.py
+++ b/lowhaio.py
@@ -11,6 +11,7 @@ from socket import (
 
 
 ConnectionPool = namedtuple('ConnectionPool', ('connection'))
+Connection = namedtuple('Connection', ('sock'))
 
 
 @asynccontextmanager
@@ -24,12 +25,11 @@ async def connection_pool(loop):
         await loop.sock_connect(sock, (ip_address, port))
 
         try:
-            yield
+            yield Connection(sock)
         finally:
             try:
                 sock.shutdown(SHUT_RDWR)
-            except OSError:
-                pass
-            sock.close()
+            finally:
+                sock.close()
 
     yield ConnectionPool(connection=connection)

--- a/test.py
+++ b/test.py
@@ -120,11 +120,6 @@ async def sock_accept(loop, server_sock, on_listening, create_client_task):
         raise
 
 
-async def cancel(task):
-    task.cancel()
-    await asyncio.sleep(0)
-
-
 class TestBasic(unittest.TestCase):
 
     @async_test


### PR DESCRIPTION
Unsure if this is good for all cases, but I suspect _not_ swallowing exceptions
unless absolutely required is a better place to start in terms of responding to
errors later.