### PR TITLE
fix: escape for http logger non-placeholder chars

### DIFF
--- a/lowhaio.py
+++ b/lowhaio.py
@@ -46,7 +46,9 @@ class HttpLoggerAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         return \
             ('[http] %s' % (msg,), kwargs) if not self.extra else \
-            ('[http:%s] %s' % (','.join(str(v) for v in self.extra.values()), msg), kwargs)
+            ('[http:%s] %s' % (','.join(
+                str(v).replace('%', '%%') for v in self.extra.values()
+            ), msg), kwargs)
 
 
 def get_logger_adapter_default(extra):

--- a/test.py
+++ b/test.py
@@ -670,7 +670,7 @@ class TestEndToEnd(unittest.TestCase):
         async for chunk in body:
             m.update(chunk)
 
-        self.assertEqual(m.hexdigest(), '6cb91af4ed4c60c11613b75cd1fc6116')
+        self.assertEqual(m.hexdigest(), 'd41d8cd98f00b204e9800998ecf8427e')
 
     @async_test
     async def test_http_get_small_via_ip_address(self):


### PR DESCRIPTION
* http logger adapter's context msg was being passed around and transformed into a pre-formatted string with more placeholders than it actually has
* this PR escapes placeholder characters in the context msg
* fix response from test test_http_get_small_via_dns (new response from http://www.ovh.net/files/1Mio.dat)